### PR TITLE
use patched redis for cluster tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,16 @@ services:
 
 language: go
 
-install: go get -t -v ./...
+before_install:
+  - make redis-server/redis-server
+
+cache:
+  directories:
+    - $HOME/redis-server
+
+install:
+  - go get -t -v ./...
+
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,28 @@
+REDIS_ARCHIVE ?= https://github.com/joomcode/redis/archive/
+REDIS_VERSION ?= 5.0.3-fixes
+
 test: testcluster testconn testredis
+
+redis-server/redis-server:
+	@echo "Building redis-$(REDIS_VERSION)..."
+	test ! -e redis-server && wget -nv -c $(REDIS_ARCHIVE)/$(REDIS_VERSION).tar.gz -O - | tar -xzC .
+	cd redis-$(REDIS_VERSION) && make -j 4
+	mkdir redis-server
+	mv redis-$(REDIS_VERSION)/src/redis-server redis-server
+	rm redis-$(REDIS_VERSION) -rf
 
 testredis:
 	go test ./redis
 
-testconn:
+testconn: redis-server/redis-server
 	killall redis-server || true
 	rm ./redisconn/redis_test_* -r || true
-	go test -count 1 ./redisconn
+	PATH=`realpath .`/redis-server/:${PATH} go test -count 1 ./redisconn
 
-testcluster:
+testcluster: redis-server/redis-server
 	killall redis-server || true
 	rm ./rediscluster/redis_test_* -r || true
-	go test -count 1 -tags debugredis ./rediscluster
+	PATH=`realpath .`/redis-server/:${PATH} go test -count 1 -tags debugredis ./rediscluster
 
 bench: benchconn benchcluster
 


### PR DESCRIPTION
Stock redis is quite unstable on cluster changes. Use our patched version.