### PR TITLE
More travis goodness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # goland
 .idea/
+
+#our version with redis with patched cluster
+redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: go
 
+go:
+  - "1.9.x"
+  - "1.12.x"
+
+env:
+  matrix:
+    - STAGE=testredis
+    - STAGE=testconn
+    - STAGE=testcluster
+
 before_install:
   - make redis-server/redis-server
 
@@ -10,18 +20,4 @@ cache:
 install:
   - go get -t -v ./...
 
-
-jobs:
-  include:
-    - go: "1.9.x"
-      script: make testredis
-    - go: "1.9.x"
-      script: make testconn
-    - go: "1.9.x"
-      script: make testcluster
-    - go: "1.12.x"  
-      script: make testredis
-    - go: "1.12.x"
-      script: make testconn
-    - go: "1.12.x"
-      script: make testcluster
+script: make $STAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-services:
-  - redis-server
-
 language: go
 
 before_install:


### PR DESCRIPTION
Added folder with our patched server to gitignore
Removed unused redis-server from travis 
Refactored job matrix to reduce copy&paste and to show testtaget in build label - https://travis-ci.com/isopov/redispipe/builds/104412474 (build is still not really stable for cluster)