### PR TITLE
Synchronize read & write access to node ping to fix data race

### DIFF
--- a/rediscluster/mapping.go
+++ b/rediscluster/mapping.go
@@ -375,7 +375,8 @@ func (n *node) updatePingLatency() {
 			latency = l
 		}
 	}
-	n.ping = uint32(latency / redisconn.PingLatencyGranularity)
+	ping := uint32(latency / redisconn.PingLatencyGranularity)
+	atomic.StoreUint32(&n.ping, ping)
 }
 
 func nextRng(state *uint32, mod uint32) uint32 {

--- a/rediscluster/slotrange.go
+++ b/rediscluster/slotrange.go
@@ -175,11 +175,11 @@ func (c *Cluster) updateMappings(slotRanges []redisclusterutil.SlotsRange) {
 			sumLatency := uint32(0)
 			for _, addr := range shard.addr {
 				node := newConfig.nodes[addr]
-				sumLatency += node.ping
+				sumLatency += atomic.LoadUint32(&node.ping)
 			}
 			for i, addr := range shard.addr {
 				node := newConfig.nodes[addr]
-				weight := sumLatency / node.ping
+				weight := sumLatency / atomic.LoadUint32(&node.ping)
 				atomic.StoreUint32(&shard.weights[i], weight)
 			}
 		}


### PR DESCRIPTION
As reported in https://github.com/joomcode/redispipe/issues/15 there is a data race when updating and reading the `ping` field of `node`. I assume it should be sufficient to read/write lock on the node's ping field.