### PR TITLE
Add github actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.12, 1.16]
+        go: [1.13, 1.16]
         stage: [testredis, testconn, testcluster]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ jobs:
 
     strategy:
       matrix:
-#        go: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16]
-        go: [1.11, 1.13, 1.16]
+        go: [1.12, 1.16]
         stage: [testredis, testconn, testcluster]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
 #        go: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16]
         go: [1.13]
-        stage: [testredis, testconn, testcluser]
+        stage: [testredis, testconn, testcluster]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+#        go: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16]
+        go: [1.13]
+        stage: [testredis, testconn, testcluser]
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Install redis
+      run: make /tmp/redis-server/redis-server
+
+    - name: Build
+      run: make ${{ matrix.stage }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
       matrix:
 #        go: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16]
         go: [1.13]
-        stage: [testredis, testconn, testcluser]
+#        stage: [testredis, testconn, testcluser]
+        stage: [testredis]
 
     steps:
 
@@ -23,8 +24,14 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
+    - name: Pwd1
+      run: pwd
+
     - name: Install redis
       run: make /tmp/redis-server/redis-server
+
+    - name: Pwd2
+      run: pwd
 
     - name: Build
       run: make ${{ matrix.stage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ jobs:
       matrix:
 #        go: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16]
         go: [1.13]
-#        stage: [testredis, testconn, testcluser]
-        stage: [testredis]
+        stage: [testredis, testconn, testcluser]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
 #        go: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16]
-        go: [1.13]
+        go: [1.11, 1.13, 1.16]
         stage: [testredis, testconn, testcluster]
 
     steps:
@@ -23,14 +23,16 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Pwd1
-      run: pwd
+    - name: Cache redis build
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/redis-server
+        key: ${{ runner.os }}-redis-${{ hashFiles('Makefile') }}
 
     - name: Install redis
       run: make /tmp/redis-server/redis-server
 
-    - name: Pwd2
-      run: pwd
 
     - name: Build
       run: make ${{ matrix.stage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
+    - name: Cache go modules
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Cache redis build
       uses: actions/cache@v2
       with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RedisPipe
 
 RedisPipe – is a client for redis that uses "implicit pipelining" for highest performance.
-
+[![Github Actions Build Status](https://github.com/joomcode/redispipe/workflows/CI/badge.svg)](https://github.com/joomcode/redispipe/actions)
 [![Build Status](https://travis-ci.com/joomcode/redispipe.svg?branch=master)](https://travis-ci.com/joomcode/redispipe)
 [![GoDoc](https://godoc.org/github.com/joomcode/redispipe?status.svg)](https://godoc.org/github.com/joomcode/redispipe)
 [![Report Card](https://goreportcard.com/badge/github.com/joomcode/redispipe)](https://goreportcard.com/report/github.com/joomcode/redispipe)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RedisPipe
 
 RedisPipe – is a client for redis that uses "implicit pipelining" for highest performance.
+
 [![Github Actions Build Status](https://github.com/joomcode/redispipe/workflows/CI/badge.svg)](https://github.com/joomcode/redispipe/actions)
 [![Build Status](https://travis-ci.com/joomcode/redispipe.svg?branch=master)](https://travis-ci.com/joomcode/redispipe)
 [![GoDoc](https://godoc.org/github.com/joomcode/redispipe?status.svg)](https://godoc.org/github.com/joomcode/redispipe)


### PR DESCRIPTION
rediscluster tests cannot complete on github actions, but they cannot complete on travis either...
Also it seems that redispipe does not support anything below go 1.13