### PR TITLE
conn with username

### DIFF
--- a/redisconn/conn.go
+++ b/redisconn/conn.go
@@ -39,6 +39,8 @@ type Opts struct {
 	DB int
 	// Password for AUTH
 	Password string
+	// Password for AUTH
+	Username string
 	// IOTimeout - timeout on read/write to socket.
 	// If IOTimeout == 0, then it is set to 1 second
 	// If IOTimeout < 0, then timeout is disabled
@@ -556,7 +558,9 @@ func (conn *Connection) dial() error {
 
 	// Password request
 	var req []byte
-	if conn.opts.Password != "" {
+	if conn.opts.Password != "" && conn.opts.Username != "" {
+		req, _ = redis.AppendRequest(req, redis.Req("AUTH", conn.opts.Username, conn.opts.Password))
+	} else if conn.opts.Password != "" {
 		req, _ = redis.AppendRequest(req, redis.Req("AUTH", conn.opts.Password))
 	}
 	const pingReq = "*1\r\n$4\r\nPING\r\n"

--- a/redisconn/conn.go
+++ b/redisconn/conn.go
@@ -39,7 +39,7 @@ type Opts struct {
 	DB int
 	// Password for AUTH
 	Password string
-	// Password for AUTH
+	// Username for AUTH
 	Username string
 	// IOTimeout - timeout on read/write to socket.
 	// If IOTimeout == 0, then it is set to 1 second


### PR DESCRIPTION
In order to test you need a redis version > 6.0.0

run:
```acl setuser redis_user >redis_password on allchannels allkeys +get +set```

Try to connect to db with the package, you will get:
```(error) ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?``` (eq `AUTH redis_password`)

connecting with valid credentials with the fix with both username and password will work (eq `AUTH redis_user redis_password`)
