### PR TITLE
Trigger topology refresh on CLUSTERDOWN

### DIFF
--- a/redis/error.go
+++ b/redis/error.go
@@ -69,6 +69,8 @@ var (
 	ErrMoved = ErrResult.NewSubtype("moved", ErrTraitClusterMove)
 	// ErrAsk - ASK response
 	ErrAsk = ErrResult.NewSubtype("ask", ErrTraitClusterMove)
+	// ErrClusterDown - CLUSTERDOWN response
+	ErrClusterDown = ErrResult.NewSubtype("clusterdown", ErrTraitNotSent)
 	// ErrLoading - redis didn't finish start
 	ErrLoading = ErrResult.NewSubtype("loading", ErrTraitNotSent)
 	// ErrExecEmpty - EXEC returns nil (WATCH failed) (it is strange, cause we don't support WATCH)

--- a/redis/reader.go
+++ b/redis/reader.go
@@ -48,6 +48,9 @@ func ReadResponse(b *bufio.Reader) (interface{}, int) {
 			}
 			return kind.New(txt).WithProperty(EKMovedTo, string(parts[2])).WithProperty(EKSlot, slot), len(line)
 		}
+		if strings.HasPrefix(txt, "CLUSTERDOWN") {
+			return ErrClusterDown.New(txt), len(line)
+		}
 		if strings.HasPrefix(txt, "LOADING") {
 			return ErrLoading.New(txt), len(line)
 		}


### PR DESCRIPTION
When Redis cluster topology changes quickly, we may encounter a replica that was detached from its master and removed from the cluster. The driver, however, may still have this replica in topology. Sending requests to this replica trigger CLUSTERDOWN responses. To facilitate faster recovery we may force topology request. This is exactly what this commit does.